### PR TITLE
Extended camb_cosmo modules to work with different values for w_0

### DIFF
--- a/lace/cosmo/camb_cosmo.py
+++ b/lace/cosmo/camb_cosmo.py
@@ -15,12 +15,14 @@ camb_fit_kmax_Mpc=1.5
 camb_extra_kmax=1.001
 
 def get_cosmology(H0=67.0, mnu=0.0, omch2=0.12, ombh2=0.022, omk=0.0,
-            As=2.1e-09, ns=0.965, nrun=0.0,pivot_scalar=0.05):
+            As=2.1e-09, ns=0.965, nrun=0.0,pivot_scalar=0.05,w=-1):
     """Given set of cosmological parameters, return CAMB cosmology object."""
 
     pars = camb.CAMBparams()
     # set background cosmology
     pars.set_cosmology(H0=H0, ombh2=ombh2, omch2=omch2, omk=omk, mnu=mnu)
+    # set DE
+    pars.set_dark_energy(w=w)
     # set primordial power
     pars.InitPower.set_params(As=As, ns=ns, nrun=nrun,pivot_scalar=pivot_scalar)
 
@@ -61,6 +63,11 @@ def get_cosmology_from_dictionary(params,cosmo_fid=None):
     # update cosmology object
     pars.set_cosmology(H0=H0, cosmomc_theta=cosmomc_theta, ombh2=ombh2,
             omch2=omch2, omk=omk, mnu=mnu, tau=tau)
+    
+    # set DE
+    if 'w' in params: w=params['w']
+    else: w=cosmo_fid.DarkEnergy.w
+    pars.set_dark_energy(w=w)
 
     # collect primorial power parameters
     if 'As' in params:

--- a/lace/setup_simulations/read_gadget.py
+++ b/lace/setup_simulations/read_gadget.py
@@ -95,6 +95,7 @@ def _build_cosmology_params_camb(config):
     params['ombh2'] = omegab*h0**2
     params['mnu'] = mnu
     params['omk'] = omegak
+    params['w'] = config['w0_fld']
     # these are not in Gadget file
     #params['TCMB'] = config["CMBTemperature"]
     #params['As'] = config["PrimordialAmp"]

--- a/lace/setup_simulations/read_genic.py
+++ b/lace/setup_simulations/read_genic.py
@@ -60,10 +60,6 @@ def _check_genic_config(config):
         raise ValueError("Can not specify input redshift")
     if config['Sigma8'] > 0.:
         raise ValueError("Can not specify Sigma8.")
-    if config['Omega_fld'] > 0:
-        raise ValueError("Omega_fld>0 not supported.")
-    if not (config['w0_fld'] == -1.0):
-        raise ValueError("w0_fld != -1 not supported.")
     if not (config['wa_fld'] == 0.0):
         raise ValueError("wa_fld != 0 not supported.")
     if config['MWDM_Therm'] > 0:
@@ -118,6 +114,7 @@ def _build_cosmology_params_camb(config):
     params['As'] = config["PrimordialAmp"]
     params['ns'] = config['PrimordialIndex']
     params['nrun'] = config['PrimordialRunning']
+    params['w'] = config['w0_fld']
 
     return params
 


### PR DESCRIPTION
As we are running a test simulation with w=-1.3, extended the necessary `camb_cosmo` functions to incorporate this