### PR TITLE
Fix get_f_of_z and use_camb_fz=True by default

### DIFF
--- a/lace/cosmo/fit_linP.py
+++ b/lace/cosmo/fit_linP.py
@@ -3,7 +3,7 @@ import os
 import camb
 from lace.cosmo import camb_cosmo
 
-def get_linP_Mpc_zs(cosmo,zs,kp_Mpc,include_f_p=True,use_camb_fz=False):
+def get_linP_Mpc_zs(cosmo,zs,kp_Mpc,include_f_p=True,use_camb_fz=True):
     """For each redshift, fit linear power parameters around kp_Mpc.
         - include_f_p to compute logarithmic groth rate at each z (slow)
         - use_camb_fz will use faster code to compute fz, but not at kp_Mpc """
@@ -15,11 +15,6 @@ def get_linP_Mpc_zs(cosmo,zs,kp_Mpc,include_f_p=True,use_camb_fz=False):
     k_Mpc, zs_out, P_Mpc = camb_cosmo.get_linP_Mpc(cosmo,zs,camb_results)
 
     assert kp_Mpc < max(k_Mpc), "Pivot higher than k_max"
-
-    # if asked for, compute also logarithmic growth rate
-    if use_camb_fz and include_f_p:
-        # fast function (already has results in hand)
-        fz=camb_cosmo.get_f_of_z(cosmo,zs,camb_results)
 
     # specify wavenumber range to fit
     kmin_Mpc = 0.5*kp_Mpc
@@ -47,7 +42,7 @@ def get_linP_Mpc_zs(cosmo,zs,kp_Mpc,include_f_p=True,use_camb_fz=False):
             # compute logarithmic growth rate at each z
             if use_camb_fz:
                 # new version, faster but uses f = f sigma_8 / sigma_8
-                f_p = fz[iz]
+                f_p=camb_cosmo.get_f_of_z(cosmo,camb_results,z)
             else:
                 # older version, slower but can ask for particular kp_Mpc
                 f_p = compute_fz(cosmo,z=z,kp_Mpc=kp_Mpc)
@@ -133,15 +128,15 @@ def fit_linP_kms(cosmo,z_star,kp_kms,deg=2,camb_results=None):
     return P_fit
 
 
-def parameterize_cosmology_kms(cosmo,results,z_star,kp_kms,use_camb_fz=False):
+def parameterize_cosmology_kms(cosmo,camb_results,z_star,kp_kms,
+            use_camb_fz=True):
     """Given input cosmology, compute set of parameters that describe 
         the linear power around z_star and wavenumbers kp_kms.
         - use_camb_fz: get f from f sigma_8 / sigma_8."""
 
     # call get_results first, to avoid calling it twice
-    zs=[z_star]
-    camb_results=results
     if camb_results==None:
+        zs=[z_star]
         camb_results = camb_cosmo.get_camb_results(cosmo,zs=zs,fast_camb=True)
 
     # compute linear power, in km/s, at z_star
@@ -158,8 +153,7 @@ def parameterize_cosmology_kms(cosmo,results,z_star,kp_kms,use_camb_fz=False):
     # get logarithmic growth rate at z_star, around kp_Mpc
     if use_camb_fz:
         # new code, compute from f sigma_8 / sigma_8 at z
-        f_of_z=camb_cosmo.get_f_of_z(cosmo,zs,camb_results)
-        f_star=f_of_z[0]
+        f_star=camb_cosmo.get_f_of_z(cosmo,camb_results,z_star)
     else:
         # old code, compute derivative of power at kp_Mpc
         kp_Mpc=kp_kms*camb_cosmo.dkms_dMpc(cosmo,z_star,camb_results)

--- a/lace/sampler/emcee_sampler.py
+++ b/lace/sampler/emcee_sampler.py
@@ -121,9 +121,11 @@ class EmceeSampler(object):
         else:
             ## Get true fit params
             ## use pivot k from the theory's recons_cosmo
-            all_truth=fit_linP.parameterize_cosmology_kms(test_sim_cosmo,
-                        self.like.theory.cosmo.z_star,
-                        self.like.theory.cosmo.kp_kms)
+            all_truth=fit_linP.parameterize_cosmology_kms(
+                        cosmo=test_sim_cosmo,
+                        camb_results=test_results,
+                        z_star=self.like.theory.cosmo.z_star,
+                        kp_kms=self.like.theory.cosmo.kp_kms)
 
         ## Take only free parameters, and store values
         ## along with LaTeX strings

--- a/notebooks/development/test_f_of_z.ipynb
+++ b/notebooks/development/test_f_of_z.ipynb
@@ -1,0 +1,218 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare different calculations of f_star\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lace.cosmo import camb_cosmo\n",
+    "from lace.cosmo import fit_linP\n",
+    "from lace.likelihood import linear_power_model\n",
+    "from lace.likelihood import CAMB_model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "67.0"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zs=[2.0,3.0,4.0]\n",
+    "z_star=3.0\n",
+    "kp_kms=0.009\n",
+    "camb_model=CAMB_model.CAMBModel(zs=zs)\n",
+    "cosmo=camb_model.cosmo\n",
+    "cosmo.H0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "camb_results=camb_model.get_camb_results()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.9813416724832917"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# new code (uses CAMB)\n",
+    "camb_cosmo.get_f_of_z(cosmo,camb_results,z=z_star)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.9813935085298198"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# old code (uses numerical derivative, not very sensitive to kp_Mpc)\n",
+    "fit_linP.compute_fz(cosmo,z=z_star,kp_Mpc=0.7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'f_star': 0.9813935108004337,\n",
+       " 'g_star': 0.9677508579459803,\n",
+       " 'linP_kms': poly1d([-0.10814521, -2.29951163, 16.09349829]),\n",
+       " 'Delta2_star': 0.3603423347991143,\n",
+       " 'n_star': -2.299511628221449,\n",
+       " 'alpha_star': -0.21629042976377164}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "linP_params_v1=fit_linP.parameterize_cosmology_kms(cosmo,camb_results,z_star,kp_kms,use_camb_fz=False)\n",
+    "linP_params_v1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'f_star': 0.9813416724832917,\n",
+       " 'g_star': 0.9677508579459803,\n",
+       " 'linP_kms': poly1d([-0.10814521, -2.29951163, 16.09349829]),\n",
+       " 'Delta2_star': 0.3603423347991143,\n",
+       " 'n_star': -2.299511628221449,\n",
+       " 'alpha_star': -0.21629042976377164}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "linP_params_v2=fit_linP.parameterize_cosmology_kms(cosmo,camb_results,z_star,kp_kms,use_camb_fz=True)\n",
+    "linP_params_v2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'f_star': 0.9813416724832917,\n",
+       " 'g_star': 0.9677508579459803,\n",
+       " 'Delta2_star': 0.3603423347991143,\n",
+       " 'n_star': -2.299511628221449,\n",
+       " 'alpha_star': -0.21629042976377164}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "linP_model=linear_power_model.LinearPowerModel(cosmo=cosmo,results=camb_results)\n",
+    "linP_model.get_params()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
@Chris-Pedersen - I decided to make a smaller PR that we can merge first to cmb_compressed, while I work on other parts (add_blobs). 

This just moves to using the CAMB function to compute f(z) instead of the numerical derivative.

I will add a notebook to show that the two functions give very similar results.