### PR TITLE
added option to specify k-range to use in linP fits

### DIFF
--- a/lace/cosmo/fit_linP.py
+++ b/lace/cosmo/fit_linP.py
@@ -112,24 +112,23 @@ def fit_polynomial(xmin,xmax,x,y,deg=2):
     return np.poly1d(poly)
 
 
-def fit_linP_kms(cosmo,z_star,kp_kms,deg=2,camb_results=None):
+def fit_linP_kms(cosmo,z_star,kp_kms,camb_results=None,
+                fit_kmin_kp=0.5,fit_kmax_kp=2.0):
     """Given input cosmology, compute linear power at z_star
         (in km/s) and fit polynomial around kp_kms.
-        - camb_results optional to avoid calling get_results. """
+        - camb_results optional to avoid calling get_results
+        - fit_kmin_kp (0.5): minimum k to fit (over kp)
+        - fit_kmax_kp (2.0): maximum k to fit (over kp) """
 
     k_kms, _, P_kms = camb_cosmo.get_linP_kms(cosmo,[z_star],
             camb_results=camb_results)
-    # specify wavenumber range to fit
-    kmin_kms = 0.5*kp_kms
-    kmax_kms = 2.0*kp_kms
     # compute ratio
-    P_fit=fit_polynomial(kmin_kms/kp_kms,kmax_kms/kp_kms,k_kms/kp_kms,
-            P_kms,deg=deg)
+    P_fit=fit_polynomial(fit_kmin_kp,fit_kmax_kp,k_kms/kp_kms,P_kms)
     return P_fit
 
 
 def parameterize_cosmology_kms(cosmo,camb_results,z_star,kp_kms,
-            use_camb_fz=True):
+                use_camb_fz=True,fit_kmin_kp=0.5,fit_kmax_kp=2.0):
     """Given input cosmology, compute set of parameters that describe 
         the linear power around z_star and wavenumbers kp_kms.
         - use_camb_fz: get f from f sigma_8 / sigma_8."""
@@ -141,7 +140,8 @@ def parameterize_cosmology_kms(cosmo,camb_results,z_star,kp_kms,
 
     # compute linear power, in km/s, at z_star
     # and fit a second order polynomial to the log power, around kp_kms
-    linP_kms = fit_linP_kms(cosmo,z_star,kp_kms,deg=2,camb_results=camb_results)
+    linP_kms = fit_linP_kms(cosmo,z_star,kp_kms,camb_results=camb_results,
+                            fit_kmin_kp=fit_kmin_kp,fit_kmax_kp=fit_kmax_kp)
 
     # translate the polynomial to our parameters
     ln_A_star = linP_kms[0]

--- a/lace/likelihood/likelihood.py
+++ b/lace/likelihood/likelihood.py
@@ -589,7 +589,7 @@ class Likelihood(object):
         # fit linear power parameters for simulation cosmology
         sim_linP_params=fit_linP.parameterize_cosmology_kms(
                 cosmo=sim_cosmo,camb_results=None,
-                z_star=z_star,kp_kms=kp_kms)
+                z_star=z_star,kp_kms=kp_kms,use_camb_fz=True)
 
         return sim_linP_params
 

--- a/lace/likelihood/linear_power_model.py
+++ b/lace/likelihood/linear_power_model.py
@@ -10,7 +10,8 @@ class LinearPowerModel(object):
             - construct with set of parameters, and store them."""
 
     def __init__(self,params=None,cosmo=None,camb_results=None,
-            z_star=3.0,kp_kms=0.009,use_camb_fz=True):
+                z_star=3.0,kp_kms=0.009,use_camb_fz=True,
+                fit_kmin_kp=0.5,fit_kmax_kp=2.0):
         """Setup model, specifying redshift and pivot point"""
 
         # store pivot point
@@ -23,7 +24,8 @@ class LinearPowerModel(object):
             self._setup_from_parameters(params)
         else:
             # parameterize cosmology and store parameters
-            self._setup_from_cosmology(cosmo,camb_results,use_camb_fz)
+            self._setup_from_cosmology(cosmo,camb_results,use_camb_fz,
+                    fit_kmin_kp=fit_kmin_kp,fit_kmax_kp=fit_kmax_kp)
 
 
     def _setup_from_parameters(self,params):
@@ -45,11 +47,13 @@ class LinearPowerModel(object):
         self.linP_params['linP_kms']=linP_kms
 
 
-    def _setup_from_cosmology(self,cosmo,camb_results,use_camb_fz):
+    def _setup_from_cosmology(self,cosmo,camb_results,use_camb_fz,
+                fit_kmin_kp,fit_kmax_kp):
         """Compute and store parameters describing the linear power."""
 
         self.linP_params=fit_linP.parameterize_cosmology_kms(cosmo,camb_results,
-                self.z_star,self.kp_kms,use_camb_fz=use_camb_fz)
+                self.z_star,self.kp_kms,use_camb_fz=use_camb_fz,
+                fit_kmin_kp=fit_kmin_kp,fit_kmax_kp=fit_kmax_kp)
 
 
     def get_params(self):

--- a/lace/likelihood/lya_theory.py
+++ b/lace/likelihood/lya_theory.py
@@ -12,13 +12,15 @@ class LyaTheory(object):
 
     def __init__(self,zs,emulator,cosmo_fid=None,verbose=False,
                     mf_model_fid=None,T_model_fid=None,kF_model_fid=None,
-                    use_camb_fz=True):
+                    use_camb_fz=True,fit_kmin_kp=0.5,fit_kmax_kp=2.0):
         """Setup object to compute predictions for the 1D power spectrum.
         Inputs:
             - zs: redshifts that will be evaluated
             - emulator: object to interpolate simulated p1d
             - cosmo_fid: CAMB object with the fiducial cosmology (optional)
-            - verbose: print information, useful to debug."""
+            - verbose: print information, useful to debug
+            - fit_kmin_kp: minimum k to use in linP fit (over kp_kms)
+            - fit_kmax_kp: maximum k to use in linP fit (over kp_kms). """
 
         self.verbose=verbose
         self.zs=zs
@@ -39,7 +41,9 @@ class LyaTheory(object):
         self.cosmo=recons_cosmo.ReconstructedCosmology(zs,
                 emu_kp_Mpc=emu_kp_Mpc,
                 like_z_star=like_z_star,like_kp_kms=like_kp_kms,
-                cosmo_fid=cosmo_fid,use_camb_fz=use_camb_fz,verbose=verbose)
+                cosmo_fid=cosmo_fid,use_camb_fz=use_camb_fz,
+                fit_kmin_kp=fit_kmin_kp,fit_kmax_kp=fit_kmax_kp,
+                verbose=verbose)
 
         # setup fiducial IGM models
         if mf_model_fid:

--- a/lace/likelihood/recons_cosmo.py
+++ b/lace/likelihood/recons_cosmo.py
@@ -10,7 +10,8 @@ class ReconstructedCosmology(object):
         reconstruct a cosmology object."""
 
     def __init__(self,zs,emu_kp_Mpc,like_z_star,like_kp_kms,
-            cosmo_fid=None,use_camb_fz=True,verbose=False):
+                cosmo_fid=None,use_camb_fz=True,
+                fit_kmin_kp=0.5,fit_kmax_kp=2.0,verbose=False):
         """Setup object to reconstruct cosmology from linear power parameters.
             - zs: redshifts where we want predictions (call emulator)
             - emu_kp_Mpc: pivot point in Mpc used in the emulator
@@ -18,6 +19,8 @@ class ReconstructedCosmology(object):
             - like_kp_kms: pivot point in likelihood parameterization (s/km)
             - cosmo_fid: CAMB object describing fiducial cosmology
             - use_camb_fz: use CAMB to compute f_star (faster)
+            - fit_kmin_kp: minimum k to use in linP fit (over kp_kms)
+            - fit_kmax_kp: maximum k to use in linP fit (over kp_kms)
             - verbose: print information for debugging."""
 
         self.verbose=verbose
@@ -46,7 +49,8 @@ class ReconstructedCosmology(object):
                 cosmo=self.cosmo_fid,
                 camb_results=self.camb_results_fid,
                 z_star=like_z_star,kp_kms=like_kp_kms,
-                use_camb_fz=self.use_camb_fz)
+                use_camb_fz=self.use_camb_fz,
+                fit_kmin_kp=fit_kmin_kp,fit_kmax_kp=fit_kmax_kp)
         if self.verbose: print('setup linP model for fiducial cosmology')
 
         # store pivot point for convenience


### PR DESCRIPTION
Not ready yet, but opening this PR for discussion.

I added code to chose the k-range used in the fitting. Current is 0.5 < k / k_p < 2.0, but if we really want to use localized derivatives it would be better to use something like 0.95 < k / k_p < 1.05.  Less than that is dangerous, I guess, since numpy might not have enough points to fit the polynomial.

The alternative could have been to provide the fixed alpha you want to use in the fit (when compressing at fixed alpha). Then the code would remove that curvature from the linear power and then fit a simple power law. I didn't implement this because the other was easier to do and to explain.