### PR TITLE
Renamed recons_cosmo object

### DIFF
--- a/lace/likelihood/full_theory.py
+++ b/lace/likelihood/full_theory.py
@@ -67,28 +67,19 @@ class FullTheory(object):
         else:
             self.kF_model_fid = pressure_model.PressureModel()
 
-        ## if we are using compression, need a recons_cosmo object
-        if self.use_compression!=0:
-            ## For now we hardcode z_star and kp_kms, since
-            ## these are also hardcoded in lya_theory.py
-
-# Chris, I would use a different name, to make clear what "cosmo" means
-# Maybe something like cosmo_fid_compression would be clearer
-
-            self.cosmo=recons_cosmo.ReconstructedCosmology(zs,
-                emu_kp_Mpc=self.emu_kp_Mpc,
-                like_z_star=3.0,like_kp_kms=0.009,
-                cosmo_fid=None,
-                use_camb_fz=self.use_camb_fz,
-                verbose=self.verbose)
-            ## Get fiducial values for linP params,
-            ## for alpha_star, f_star, g_star
-            cosmo_fid=camb_cosmo.get_cosmology()
-            linP_model=linear_power_model.LinearPowerModel(
-                        cosmo=cosmo_fid,
-                        camb_results=None,
-                        use_camb_fz=self.use_camb_fz)
-            self.fid_linP_params=linP_model.linP_params
+        ## Set up a recons_cosmo object
+        self.recons=recons_cosmo.ReconstructedCosmology(zs,
+                                    emu_kp_Mpc=self.emu_kp_Mpc,
+                                    like_z_star=3.0,like_kp_kms=0.009,
+                                    cosmo_fid=None,
+                                    use_camb_fz=self.use_camb_fz,
+                                    verbose=self.verbose)
+        cosmo_fid=camb_cosmo.get_cosmology()
+        linP_model=linear_power_model.LinearPowerModel(
+                    cosmo=cosmo_fid,
+                    camb_results=None,
+                    use_camb_fz=self.use_camb_fz)
+        self.fid_linP_params=linP_model.linP_params
 
 
     def fixed_background(self,like_params):
@@ -182,8 +173,8 @@ class FullTheory(object):
                 linP_model.linP_params["f_star"]=self.fid_linP_params["f_star"]
                 linP_model.linP_params["g_star"]=self.fid_linP_params["g_star"]
 
-            linP_Mpc_params=self.cosmo.get_linP_Mpc_params(linP_model)
-            M_of_zs=self.cosmo.reconstruct_M_of_zs(linP_model)
+            linP_Mpc_params=self.recons.get_linP_Mpc_params(linP_model)
+            M_of_zs=self.recons.reconstruct_M_of_zs(linP_model)
             if return_blob:
                 blob=self.get_blob(camb_model=camb_model)
         ## Otherwise calculate the emulator calls directly with no compression

--- a/lace/likelihood/likelihood.py
+++ b/lace/likelihood/likelihood.py
@@ -598,10 +598,7 @@ class Likelihood(object):
 
         self.verbose=False
         self.theory.verbose=False
-        try: ## Only lya_theory object has a theory.cosmo object
-            self.theory.cosmo.verbose=False
-        except:
-            pass
+        self.theory.recons.verbose=False
         self.theory.emulator.verbose=False
         self.theory.emulator.archive.verbose=False
 
@@ -611,10 +608,7 @@ class Likelihood(object):
 
         self.verbose=True
         self.theory.verbose=True
-        try:
-            self.theory.cosmo.verbose=True
-        except:
-            pass
+        self.theory.recons.verbose=True
         self.theory.emulator.verbose=True
         self.theory.emulator.archive.verbose=True
 
@@ -644,9 +638,8 @@ class Likelihood(object):
     def get_simulation_linP_params(self,sim_num):
         """ Compute Delta2_star and n_star for a given simulation in suite"""
 
-        # this function should only be called when using compressed parameters
-        z_star = self.theory.cosmo.z_star
-        kp_kms = self.theory.cosmo.kp_kms
+        z_star = self.theory.recons.z_star
+        kp_kms = self.theory.recons.kp_kms
 
         # setup cosmology from GenIC file
         sim_cosmo=self.theory.emulator.archive.get_simulation_cosmology(sim_num)

--- a/lace/likelihood/lya_theory.py
+++ b/lace/likelihood/lya_theory.py
@@ -36,7 +36,7 @@ class LyaTheory(object):
         like_kp_kms=0.009
 
         # setup object to compute linear power for any cosmology
-        self.cosmo=recons_cosmo.ReconstructedCosmology(zs,
+        self.recons=recons_cosmo.ReconstructedCosmology(zs,
                 emu_kp_Mpc=emu_kp_Mpc,
                 like_z_star=like_z_star,like_kp_kms=like_kp_kms,
                 cosmo_fid=cosmo_fid,use_camb_fz=use_camb_fz,verbose=verbose)
@@ -61,7 +61,7 @@ class LyaTheory(object):
             - return_blob will return extra information about the call."""
 
         # setup linear power using list of likelihood parameters
-        linP_model=self.cosmo.get_linP_model(like_params)
+        linP_model=self.recons.get_linP_model(like_params)
         # setup IMG models using list of likelihood parameters
         igm_models=self.get_igm_models(like_params)
         mf_model=igm_models['mf_model']
@@ -70,7 +70,7 @@ class LyaTheory(object):
 
         # compute linear power parameters at all redshifts
         # (recons_cosmo already knows the pivot point emu_kp_Mpc)
-        linP_Mpc_params=self.cosmo.get_linP_Mpc_params(linP_model)
+        linP_Mpc_params=self.recons.get_linP_Mpc_params(linP_model)
 
         # loop over redshifts and store emulator calls
         emu_calls=[]
@@ -82,7 +82,7 @@ class LyaTheory(object):
             model['mF']=mf_model.get_mean_flux(z)
             model['gamma']=T_model.get_gamma(z)
             sigT_kms=T_model.get_sigT_kms(z)
-            dkms_dMpc=self.cosmo.reconstruct_Hubble_iz(iz,linP_model)/(1+z)
+            dkms_dMpc=self.recons.reconstruct_Hubble_iz(iz,linP_model)/(1+z)
             model['sigT_Mpc']=sigT_kms/dkms_dMpc
             kF_kms=kF_model.get_kF_kms(z)
             model['kF_Mpc']=kF_kms*dkms_dMpc
@@ -142,7 +142,7 @@ class LyaTheory(object):
 
         # setup linear power using list of likelihood parameters
         # we will need this to reconstruct H(z)
-        linP_model=self.cosmo.get_linP_model(like_params=like_params)
+        linP_model=self.recons.get_linP_model(like_params=like_params)
 
         # loop over redshifts and compute P1D
         p1d_kms=[]
@@ -153,7 +153,7 @@ class LyaTheory(object):
             # will call emulator for this model
             model=emu_calls[iz]
             # emulate p1d
-            dkms_dMpc=self.cosmo.reconstruct_Hubble_iz(iz,linP_model)/(1+z)
+            dkms_dMpc=self.recons.reconstruct_Hubble_iz(iz,linP_model)/(1+z)
 
             k_Mpc = k_kms * dkms_dMpc
             if return_covar:
@@ -193,7 +193,7 @@ class LyaTheory(object):
     def get_parameters(self):
         """Return parameters in models, even if not free parameters"""
 
-        params=self.cosmo.linP_model_fid.get_likelihood_parameters()
+        params=self.recons.linP_model_fid.get_likelihood_parameters()
         for par in self.mf_model_fid.get_parameters():
             params.append(par)
         for par in self.T_model_fid.get_sigT_kms_parameters():


### PR DESCRIPTION
The `recons_cosmo` object was called `x.cosmo` in the theory objects, which is a bit confusing as it has the same name as the `camb` cosmology objects used in other part of the code. Renamed this to `x.recons`. Also made it so that the `lya_theory` has a `recons` object regardless of which compression is used - it costs nothing to initialise and the code is more likely to break if classes have different properties based on initialisation arguments.