### PR TITLE
Bugfixes - 1 significant bug in the CMB prior, 2 more minor bugs in sampler and likelihood

### DIFF
--- a/lace/likelihood/full_theory.py
+++ b/lace/likelihood/full_theory.py
@@ -16,7 +16,7 @@ class FullTheory(object):
     def __init__(self,zs,emulator=None,true_camb_model=None,verbose=False,
                     mf_model_fid=None,T_model_fid=None,kF_model_fid=None,
                     pivot_scalar=0.05,theta_MC=True,use_compression=0,
-                    use_camb_fz=True):
+                    use_camb_fz=True,cosmo_fid=None):
         """Setup object to compute predictions for the 1D power spectrum.
         Inputs:
             - zs: redshifts that will be evaluated
@@ -31,7 +31,10 @@ class FullTheory(object):
                                 f_star and g_star
                     if set to 2, will compress into Delta2_star and n_star,
                                 and use a fiducial g_star and f_star
-                                in the reconstruction  """
+                                in the reconstruction
+            - cosmo_fid: Can pass a cosmology to be used as the fiducial in the
+                         reconstruction, in the case of running with compression.
+                         If set to None will use our standard fiducial cosmology.  """
 
         self.verbose=verbose
         self.zs=zs
@@ -71,7 +74,7 @@ class FullTheory(object):
         self.recons=recons_cosmo.ReconstructedCosmology(zs,
                                     emu_kp_Mpc=self.emu_kp_Mpc,
                                     like_z_star=3.0,like_kp_kms=0.009,
-                                    cosmo_fid=None,
+                                    cosmo_fid=cosmo_fid,
                                     use_camb_fz=self.use_camb_fz,
                                     verbose=self.verbose)
         cosmo_fid=camb_cosmo.get_cosmology()

--- a/lace/likelihood/likelihood.py
+++ b/lace/likelihood/likelihood.py
@@ -114,7 +114,8 @@ class Likelihood(object):
                         true_camb_model=camb_model_sim,verbose=self.verbose,
                         pivot_scalar=pivot_scalar,
                         theta_MC=("cosmomc_theta" in free_param_names),
-                        use_compression=use_compression)
+                        use_compression=use_compression,
+                        cosmo_fid=sim_cosmo)
                 assert self.data.mock_sim.sim_cosmo.InitPower.pivot_scalar == self.theory.true_camb_model.cosmo.InitPower.pivot_scalar
 
                 if not full:
@@ -266,6 +267,8 @@ class Likelihood(object):
                 cosmo_dict["As"]=like_param.value
             elif like_param.name=="ns":
                 cosmo_dict["ns"]=like_param.value
+            elif like_param.name=="mnu":
+                cosmo_dict["mnu"]=like_param.value
 
         assert len(cosmo_dict)>0, "No CMB cosmology parameters found in sampling space"
 

--- a/lace/sampler/emcee_sampler.py
+++ b/lace/sampler/emcee_sampler.py
@@ -186,9 +186,8 @@ class EmceeSampler(object):
                 # Check convergence
                 converged = np.all(tau * 100 < sampler.iteration)
                 converged &= np.all(np.abs(old_tau - tau) / tau < 0.01)
-                if force_steps == False:
-                    if converged:
-                        break
+                if converged:
+                    break
                 old_tau = tau
 
         else:


### PR DESCRIPTION
Identifed a few bugs to fix, starting with the most serious:

1. When including the CMB likelihood, the neutrino mass likelihood parameter wasn't being passed to the cmb_like object, so changes to neutrino mass were not being considered in the prior evaluation. This is why we saw an abnormally flat CMB prior in neutrino mass when running the sampler on CMB only. This bug was consistent across all compression tests so shouldn't have any implications on our conclusions so far. I've set the compression chains to rerun with the fix, I think we can just expect that all the constraints tighten, we will just have a better estimate of the CMB prior to compare the P1D contribution to.
2. Fixed a bug where you can set up a likelihood object with use_sim_cosmo=True, and it will use the mock simulation cosmology as the true cosmology, for testing purposes. This wasn't being propagated to the theory objects before.
3. Fixed a minor bug in the sampler when running without parallelisation.