### PR TITLE
Updated compression "3" values for a polyfit emulator

### DIFF
--- a/lace/data/data_MPGADGET.py
+++ b/lace/data/data_MPGADGET.py
@@ -18,14 +18,18 @@ class P1D_MPGADGET(base_p1d_data.BaseDataP1D):
     """ Class to load an MP-Gadget simulation as a mock
     data object. Can use PD2013 or Chabanier2019 covmats """
 
-    def __init__(self,basedir=None,sim_label=None,skewers_label=None,
-            zmin=None,zmax=None,z_list=None,kp_Mpc=0.7,
-            data_cov_label="Chabanier2019",data_cov_factor=1.,
-            add_syst=True,pivot_scalar=0.05,polyfit=False):
+    def __init__(self,basedir="/p1d_emulator/sim_suites/Australia20/",
+            sim_label="central",
+            skewers_label='Ns500_wM0.05',
+            zmin=None,zmax=None,z_list=None,
+            kp_Mpc=0.7,
+            data_cov_label="Chabanier2019",data_cov_factor=0.2,
+            add_syst=True,pivot_scalar=0.05,polyfit=True):
         """ Read mock P1D from MP-Gadget sims, and returns mock measurement:
             - basedir: directory with simulations outputs for a given suite
             - sim_label: can be either:
                 -- an integer, index from the Latin hypercube for that suite
+                -- "central", which takes the central sim from the LH
                 -- "nu", which corresponds to the 0.3eV neutrino sim
                 -- "h", which corresponds to the simulation with h=0.74
             - skewers_label: string identifying skewer extraction from sims
@@ -37,21 +41,9 @@ class P1D_MPGADGET(base_p1d_data.BaseDataP1D):
             - polyfit: Smooth the mock data by using a polynomial fit to the P1D
         """
 
-        if basedir:
-            self.basedir=basedir
-        else:
-            self.basedir="/p1d_emulator/sim_suites/Australia20/"
-
-        if skewers_label:
-            self.skewers_label=skewers_label
-        else:
-            self.skewers_label='Ns500_wM0.05'
-
-        if sim_label:
-            self.sim_label=sim_label
-        else:
-            self.sim_label=0
-
+        self.basedir=basedir
+        self.skewers_label=skewers_label
+        self.sim_label=sim_label
         self.data_cov_factor=data_cov_factor
         self.data_cov_label=data_cov_label
         self.kp_Mpc=kp_Mpc

--- a/lace/likelihood/likelihood.py
+++ b/lace/likelihood/likelihood.py
@@ -147,7 +147,9 @@ class Likelihood(object):
             assert igm==False, "Cannot run marginalised P1D with free IGM parameters"
 
             ## Set up marginalised p1d likelihood object
-            self.marg_p1d=marg_p1d_like.MargP1DLike(self.data.sim_label,self.reduced_IGM)
+            self.marg_p1d=marg_p1d_like.MargP1DLike(self.data.sim_label,
+                                                    self.reduced_IGM,
+                                                    self.data.polyfit)
 
         if self.verbose: print(len(self.free_params),'free parameters')
 

--- a/lace/likelihood/marg_p1d_like.py
+++ b/lace/likelihood/marg_p1d_like.py
@@ -4,12 +4,14 @@ class MargP1DLike(object):
     """ Object to return a Gaussian approximation to the marginalised
         likelihood on Delta2_star and n_star from a mock simulation """
     
-    def __init__(self,sim_label,reduced_IGM=False):
-        """ sim_label will be the simulation we are using
-            as a mock dataset (will add later)
-            reduced_IGM is a flag that will use a
-            covariance matrix after marginalising over only
-            ln_tau_0, purely in the interests of running faster chains
+    def __init__(self,sim_label,reduced_IGM=False,polyfit=False):
+        """  - sim_label: simulation we are using
+               as a mock dataset
+             - reduced_IGM: use a covariance matrix after
+               marginalising over only ln_tau_0, in the interests
+               of running faster chains.
+             - polyfit: Use Gaussian approximations fit from polyfit
+               constraints instead of k_bin emulator
             
             We set the truth values from the sim_label, and the cov
             from the reduced_IGM flag as the covariance is roughly
@@ -17,24 +19,39 @@ class MargP1DLike(object):
 
         ## Hardcoding the central sim values for now
         self.sim_label=sim_label
-        if sim_label=="central":
-            self.true=np.array([0.3462089,-2.29839649])
-        elif sim_label=="h":
-            self.true=np.array([0.3393979,-2.29942019])
-        elif sim_label=="nu":
-            self.true=np.array([0.3425163,-2.29975242])
-        else:
-            print("Do not have truth values stored for the mock simulation")
-
         self.reduced_IGM=reduced_IGM
-        if self.reduced_IGM==False:
-            ## Use covariance after a full marginalisation
-            self.cov=np.array([[1.77781998e-04, 4.56077117e-05],
+
+        if polyfit==False:
+            ## Use values for kbin emulator
+            ## Set mean values
+            if sim_label=="central":
+                self.true=np.array([0.3462089,-2.29839649])
+            elif sim_label=="h":
+                self.true=np.array([0.3393979,-2.29942019])
+            elif sim_label=="nu":
+                self.true=np.array([0.3425163,-2.29975242])
+            else:
+                raise Exception("Do not have truth values stored for the mock simulation")
+            ## Set covariance - not dependent on simulation for kbin emulator
+            if self.reduced_IGM==False:
+                ## Use covariance after a full marginalisation
+                self.cov=np.array([[1.77781998e-04, 4.56077117e-05],
                                 [4.56077117e-05, 4.47283109e-05]])
-        else:
+            else:
             ## Use covariance after a marginalisation over only ln_tau_0
-            self.cov=np.array([[8.20389465e-05, 3.19638330e-05],
+                self.cov=np.array([[8.20389465e-05, 3.19638330e-05],
                                 [3.19638330e-05, 1.94088790e-05]])
+        else:
+            ## Use values for polyfit emulator
+            if sim_label=="nu":
+                self.true=np.array([0.37,-2.293])
+            else:
+                raise Exception("No fits for this sim from polyfit emulator")
+            self.cov=np.array([[1.8e-04, 7.2e-05],
+                                [7.2e-05, 1.2e-04]])
+            if reduced_IGM==True:
+                raise Exception("No fits for reduced IGM runs for polyfit emulator")
+
         self.icov=np.linalg.inv(self.cov)
 
         


### PR DESCRIPTION
Have added a Gaussian approximation to the polyfit constraints on Delta2_star and n_star from the neutrino sim, so we can run the 3rd stage of the compression. The fit isn't perfect, I mostly focused on matching the 1 sigma contours. I guess we could try and run some kind of minimiser over the KL divergence instead, but we can discuss that next week, and I'll work with this for now.

![gauss_approx_nu](https://user-images.githubusercontent.com/16047009/152658447-2bf7de92-570e-4f97-b869-88e1c078738b.png)
